### PR TITLE
Fix Youtube links by using latest yt-dlp

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,4 @@
 openai
 pydub
 tqdm
+yt-dlp


### PR DESCRIPTION
Fixes error "ERROR: [youtube] XXX: Unable to extract uploader id"